### PR TITLE
fix: error showing when one is trying to use item other than armor

### DIFF
--- a/module/helpers/items/itemDetails.mjs
+++ b/module/helpers/items/itemDetails.mjs
@@ -136,7 +136,7 @@ function _armorBonus(item) {
   const armorBonus = item.system?.armorBonus ?? 0;
   const properties = item.system?.properties;
   let content = "";
-  const sumOfBonus = armorBonus + properties?.reinforced.active + properties?.sturdy.active;
+  const sumOfBonus = armorBonus + properties?.reinforced?.active + properties?.sturdy?.active;
   if (sumOfBonus) {
     content += "<div class='detail'>";
     content += `+ ${sumOfBonus} PD`;
@@ -149,7 +149,7 @@ function _armorPdr(item) {
   const armorPdr = item.system?.armorPdr ?? 0;
   const properties = item.system?.properties;
   let content = "";
-  const sumOfBonus = armorPdr + properties?.dense.active;
+  const sumOfBonus = armorPdr + properties?.dense?.active;
   if (sumOfBonus) {
     content += "<div class='detail'>";
     content += `+ ${sumOfBonus} PDR`;


### PR DESCRIPTION
Przedmioty inne niż zbroja, mają obiekt `properties`, więc logika przechodzi przez pierwszy optional chaining, ale obiekt `properties` nie posiada pól `dense`, `sturdy` i `reinforced` więc program zwraca błąd przy próbie wyciągnięcia wartości `active`. Optional chaining jest potrzebny na obu poziomach